### PR TITLE
literally paranoia

### DIFF
--- a/public/js/waybar.js
+++ b/public/js/waybar.js
@@ -183,7 +183,7 @@ document.getElementById("searchButton").onclick = function (event) {
         );
         let searchUrl = preferredSearchEngine || "https://www.bing.com/search?q=";
 
-        if (!url.includes(".")) {
+        if (!url.includes(".") || url.split(".").slice(1).toString().includes(" ")) {
             url = searchUrl + encodeURIComponent(url);
         } else {
             if (!url.startsWith("http://") && !url.startsWith("https://")) {


### PR DESCRIPTION
currently, if your search/url query contains a period, it will try to load it as a URL, no matter what. this is usually ok, except in the (rare) instance of a google search containing a period. so, if you type "hello world. this is a test" it will try to load "https:\//hello world,%20this%20is%20a%20test". what this PR does is, instead of using a search engine if the query does NOT contain a period, it also checks if there are any spaces after the period. if there are, it will use a search engine. otherwise, try to load a URL. so there's your EXTENDED DESCRIPTION (i probably coulda made this into like two sentences 😭)